### PR TITLE
fixing font scaling issues

### DIFF
--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -575,7 +575,7 @@ void CommandPalette(const char* name)
         gi.Search.RefreshSearchResults();
     }
 
-    ImGui::BeginChild("SearchResults", ImVec2(width, search_result_window_height));
+    ImGui::BeginChild("SearchResults", ImVec2(width, search_result_window_height), ImGuiChildFlags_FrameStyle);
 
     auto window = ImGui::GetCurrentContext()->CurrentWindow;
     auto draw_list = window->DrawList;
@@ -623,6 +623,9 @@ void CommandPalette(const char* name)
         gi.ExtraData.resize(item_count);
     }
 
+    ImGuiContext& g = *GImGui;
+    const auto& style = g.Style;
+
     // Flag used to delay item selection until after the loop ends
     bool select_focused_item = false;
     for (int i = 0; i < item_count; ++i) {
@@ -641,6 +644,20 @@ void CommandPalette(const char* name)
             window->DC.CursorPos,
             window->DC.CursorPos + ImGui::CalcItemSize(size, 0.0f, 0.0f),
         };
+
+        // extend the bounding box so that the filled background covers the entire item
+        {
+            const float spacing_x = style.ItemSpacing.x;
+            const float spacing_y = style.ItemSpacing.y;
+            const float spacing_L = IM_TRUNC(spacing_x * 0.50f);
+            const float spacing_U = IM_TRUNC(spacing_y * 0.50f);
+            rect.Min.x -= spacing_L;
+            rect.Min.y -= spacing_U;
+            rect.Max.x += (spacing_x - spacing_L);
+            rect.Max.y += (spacing_y - spacing_U);
+            // if (g.IO.KeyCtrl)
+            //     ImGui::GetForegroundDrawList()->AddRect(rect.Min, rect.Max, IM_COL32(0, 255, 0, 255));
+        }
 
         bool& hovered = gi.ExtraData[i].Hovered;
         bool& held = gi.ExtraData[i].Held;
@@ -736,7 +753,7 @@ void CommandPalette(const char* name)
             draw_list->AddText(text_pos, text_color_regular, text);
         }
 
-        ImGui::ItemSize(rect);
+        ImGui::ItemSize(size, 0.0f);
         if (!ImGui::ItemAdd(rect, id)) {
             continue;
         }

--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -61,6 +61,7 @@ public:
     const char* GetItem(int idx) const;
     const char* GetIcon(int idx) const;
     const char* GetShortcut(int idx) const;
+    bool HasSubsequent(int idx) const;
     void SelectItem(int idx);
 
     void PushOptions(std::vector<std::string> options);
@@ -93,6 +94,7 @@ public:
     const char* GetItem(int idx) const;
     const char* GetIcon(int idx) const;
     const char* GetShortcut(int idx) const;
+    bool HasSubsequent(int idx) const;
 
     bool IsActive() const;
 
@@ -284,6 +286,15 @@ const char* ExecutionManager::GetShortcut(int idx) const
     }
 }
 
+bool ExecutionManager::HasSubsequent(int idx) const
+{
+    if (m_ExecutingCommand) {
+        return false;
+    } else {
+        return gContext->Commands[idx].SubsequentCallback != nullptr;
+    }
+}
+
 template <class TFunc, class... Ts>
 static void InvokeSafe(const TFunc& func, Ts&&... args)
 {
@@ -373,6 +384,12 @@ const char* SearchManager::GetShortcut(int idx) const
 {
     int actualIdx = SearchResults[idx].ItemIndex;
     return m_Instance->Session.GetShortcut(actualIdx);
+}
+
+bool SearchManager::HasSubsequent(int idx) const
+{
+    int actualIdx = SearchResults[idx].ItemIndex;
+    return m_Instance->Session.HasSubsequent(actualIdx);
 }
 
 bool SearchManager::IsActive() const
@@ -720,7 +737,7 @@ void CommandPalette(const char* name, const char* hint)
             ImVec2 text_size = ImGui::CalcTextSize(text, NULL, true);
             float icon_w = (icon && icon[0]) ? ImGui::CalcTextSize(icon, NULL).x : 0.0f;
             float shortcut_w = (shortcut && shortcut[0]) ? ImGui::CalcTextSize(shortcut, NULL).x : 0.0f;
-            const float checkmark_w = 0.f;
+            float checkmark_w = IM_TRUNC(g.FontSize * 1.20f);
             float min_w = window->DC.MenuColumns.DeclColumns(icon_w, text_size.x, shortcut_w, checkmark_w); // Feedback for next frame
             float stretch_w = ImMax(0.0f, ImGui::GetContentRegionAvail().x - min_w);
 
@@ -734,6 +751,8 @@ void CommandPalette(const char* name, const char* hint)
                 draw_list->AddText(pos + ImVec2(offsets->OffsetShortcut + stretch_w, 0.0f), ImGui::GetColorU32(ImGuiCol_Text), shortcut);
                 ImGui::PopStyleColor();
             }
+            if (gi.Search.HasSubsequent(i))
+                ImGui::RenderArrow(window->DrawList, pos + ImVec2(offsets->OffsetMark + stretch_w + g.FontSize * 0.30f, 0.0f), ImGui::GetColorU32(ImGuiCol_Text), ImGuiDir_Right);
 
             auto text_pos = pos + ImVec2(offsets->OffsetLabel, 0.0f);
             int range_begin;
@@ -815,7 +834,7 @@ void CommandPalette(const char* name, const char* hint)
             ImVec2 text_size = ImGui::CalcTextSize(text, NULL, true);
             float icon_w = (icon && icon[0]) ? ImGui::CalcTextSize(icon, NULL).x : 0.0f;
             float shortcut_w = (shortcut && shortcut[0]) ? ImGui::CalcTextSize(shortcut, NULL).x : 0.0f;
-            const float checkmark_w = 0.f;
+            float checkmark_w = IM_TRUNC(g.FontSize * 1.20f);
             float min_w = window->DC.MenuColumns.DeclColumns(icon_w, text_size.x, shortcut_w, checkmark_w); // Feedback for next frame
             float stretch_w = ImMax(0.0f, ImGui::GetContentRegionAvail().x - min_w);
 
@@ -830,6 +849,8 @@ void CommandPalette(const char* name, const char* hint)
                 draw_list->AddText(pos + ImVec2(offsets->OffsetShortcut + stretch_w, 0.0f), ImGui::GetColorU32(ImGuiCol_Text), shortcut);
                 ImGui::PopStyleColor();
             }
+            if (gi.Session.HasSubsequent(i))
+                ImGui::RenderArrow(window->DrawList, pos + ImVec2(offsets->OffsetMark + stretch_w + g.FontSize * 0.30f, 0.0f), ImGui::GetColorU32(ImGuiCol_Text), ImGuiDir_Right);
         }
 
         ImGui::ItemSize(size, 0.0f);

--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -516,7 +516,7 @@ void SetNextCommandPaletteSearchBoxFocused()
     gContext->NextCommandPaletteActions.FocusSearchBox = true;
 }
 
-void CommandPalette(const char* name)
+void CommandPalette(const char* name, const char* hint)
 {
     IM_ASSERT(gContext != nullptr);
 
@@ -571,7 +571,7 @@ void CommandPalette(const char* name)
         ImGui::SetKeyboardFocusHere(0);
     }
     ImGui::SetNextItemWidth(width);
-    if (ImGui::InputText("##SearchBox", gi.Search.SearchText, IM_ARRAYSIZE(gi.Search.SearchText))) {
+    if (ImGui::InputTextWithHint("##SearchBox", hint, gi.Search.SearchText, IM_ARRAYSIZE(gi.Search.SearchText))) {
         // Search string updated, update search results
         gi.Search.RefreshSearchResults();
     }

--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -587,6 +587,7 @@ void CommandPalette(const char* name, const char* hint)
         } else {
             gi.Search.SetSearchText(text);
         }
+        gg.NextCommandPaletteActions.NewSearchText = nullptr;
     } else if (gi.PendingActions.ClearSearch) {
         refresh_search = false;
         gi.Search.ClearSearchText();
@@ -603,6 +604,7 @@ void CommandPalette(const char* name, const char* hint)
         // Focus the search box when user first brings command palette window up
         // Note: this only affects the next frame
         ImGui::SetKeyboardFocusHere(0);
+        gg.NextCommandPaletteActions.FocusSearchBox = false;
     }
     ImGui::SetNextItemWidth(width);
     if (ImGui::InputTextWithHint("##SearchBox", hint, gi.Search.SearchText, IM_ARRAYSIZE(gi.Search.SearchText))) {
@@ -840,11 +842,6 @@ void CommandPalette(const char* name, const char* hint)
         }
     }
 
-    if (ImGui::IsKeyPressed(ImGuiKey_UpArrow)) {
-        gi.CurrentSelectedItem = ImMax(gi.CurrentSelectedItem - 1, 0);
-    } else if (ImGui::IsKeyPressed(ImGuiKey_DownArrow)) {
-        gi.CurrentSelectedItem = ImMin(gi.CurrentSelectedItem + 1, item_count - 1);
-    }
     if (ImGui::IsKeyPressed(ImGuiKey_Enter) || select_focused_item) {
         if (gi.Search.IsActive() && !gi.Search.SearchResults.empty()) {
             auto idx = gi.Search.SearchResults[gi.CurrentSelectedItem].ItemIndex;
@@ -856,7 +853,11 @@ void CommandPalette(const char* name, const char* hint)
 
     ImGui::EndChild();
 
-    gg.NextCommandPaletteActions = {};
+    if (ImGui::Shortcut(ImGuiKey_UpArrow, ImGuiInputFlags_Repeat)) {
+        gi.CurrentSelectedItem = ImMax(gi.CurrentSelectedItem - 1, 0);
+    } else if (ImGui::Shortcut(ImGuiKey_DownArrow, ImGuiInputFlags_Repeat)) {
+        gi.CurrentSelectedItem = ImMin(gi.CurrentSelectedItem + 1, item_count - 1);
+    }
 
     ImGui::PopID();
     gg.CurrentCommandPalette = nullptr;

--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -298,8 +298,8 @@ void ExecutionManager::SelectItem(int idx)
     size_t initial_call_stack_height = m_CallStack.size();
 
     // Guarding aginst invalid index.
-    if (idx >= gContext->Commands.size()) return;
-    IM_ASSERT(idx < gContext->Commands.size());
+    if (idx >= GetItemCount()) return;
+    IM_ASSERT(idx < GetItemCount());
 
     if (cmd == nullptr) {
         cmd = m_ExecutingCommand = &gContext->Commands[idx];

--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -635,7 +635,7 @@ void CommandPalette(const char* name)
 
         ImVec2 size{
             ImGui::GetContentRegionAvail().x,
-            ImMax(font_regular->FontSize, font_highlight->FontSize),
+            ImMax(font_regular->FontSize, font_highlight->FontSize) * font_scale,
         };
         ImRect rect{
             window->DC.CursorPos,
@@ -670,7 +670,7 @@ void CommandPalette(const char* name)
                     auto end = text + range_begin;
 
                     draw_list->AddText(text_pos, text_color_regular, begin, end);
-                    auto segment_size = font_regular->CalcTextSizeA(font_regular->FontSize, std::numeric_limits<float>::max(), 0.0f, begin, end);
+                    auto segment_size = font_regular->CalcTextSizeA(font_regular->FontSize * font_scale, std::numeric_limits<float>::max(), 0.0f, begin, end);
 
                     if (underline_regular) {
                         float x1 = text_pos.x;

--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -682,7 +682,7 @@ void CommandPalette(const char* name, const char* hint)
     // Could be 0.5 on macOS Retina, 1 elsewhere
     float font_scale = ImGui::GetIO().FontGlobalScale;
 
-    if (gi.ExtraData.size() < item_count) {
+    if ((int)gi.ExtraData.size() < item_count) {
         gi.ExtraData.resize(item_count);
     }
 

--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -62,6 +62,7 @@ public:
     const char* GetIcon(int idx) const;
     const char* GetShortcut(int idx) const;
     bool HasSubsequent(int idx) const;
+    bool IsChecked(int idx) const;
     void SelectItem(int idx);
 
     void PushOptions(std::vector<std::string> options);
@@ -95,6 +96,7 @@ public:
     const char* GetIcon(int idx) const;
     const char* GetShortcut(int idx) const;
     bool HasSubsequent(int idx) const;
+    bool IsChecked(int idx) const;
 
     bool IsActive() const;
 
@@ -295,6 +297,11 @@ bool ExecutionManager::HasSubsequent(int idx) const
     }
 }
 
+bool ExecutionManager::IsChecked(int idx) const
+{
+    return m_ExecutingCommand ? false : (gContext->Commands[idx].IsChecked && *gContext->Commands[idx].IsChecked);
+}
+
 template <class TFunc, class... Ts>
 static void InvokeSafe(const TFunc& func, Ts&&... args)
 {
@@ -390,6 +397,12 @@ bool SearchManager::HasSubsequent(int idx) const
 {
     int actualIdx = SearchResults[idx].ItemIndex;
     return m_Instance->Session.HasSubsequent(actualIdx);
+}
+
+bool SearchManager::IsChecked(int idx) const
+{
+    int actualIdx = SearchResults[idx].ItemIndex;
+    return m_Instance->Session.IsChecked(actualIdx);
 }
 
 bool SearchManager::IsActive() const
@@ -753,6 +766,8 @@ void CommandPalette(const char* name, const char* hint)
             }
             if (gi.Search.HasSubsequent(i))
                 ImGui::RenderArrow(window->DrawList, pos + ImVec2(offsets->OffsetMark + stretch_w + g.FontSize * 0.30f, 0.0f), ImGui::GetColorU32(ImGuiCol_Text), ImGuiDir_Right);
+            else if (gi.Search.IsChecked(i))
+                ImGui::RenderCheckMark(window->DrawList, pos + ImVec2(offsets->OffsetMark + stretch_w + g.FontSize * 0.40f, g.FontSize * 0.134f * 0.5f), ImGui::GetColorU32(ImGuiCol_Text), g.FontSize * 0.866f);
 
             auto text_pos = pos + ImVec2(offsets->OffsetLabel, 0.0f);
             int range_begin;
@@ -851,6 +866,8 @@ void CommandPalette(const char* name, const char* hint)
             }
             if (gi.Session.HasSubsequent(i))
                 ImGui::RenderArrow(window->DrawList, pos + ImVec2(offsets->OffsetMark + stretch_w + g.FontSize * 0.30f, 0.0f), ImGui::GetColorU32(ImGuiCol_Text), ImGuiDir_Right);
+            else if (gi.Session.IsChecked(i))
+                ImGui::RenderCheckMark(window->DrawList, pos + ImVec2(offsets->OffsetMark + stretch_w + g.FontSize * 0.40f, g.FontSize * 0.134f * 0.5f), ImGui::GetColorU32(ImGuiCol_Text), g.FontSize * 0.866f);
         }
 
         ImGui::ItemSize(size, 0.0f);

--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -939,10 +939,6 @@ void CommandPalette(const char* name, const char* hint)
     auto draw_list = window->DrawList;
     auto offsets = &window->DC.MenuColumns;
 
-    // Reset the MenuColumns to ensure we don't accumulate widths from previous frames or other command lists
-    // This prevents horizontal scrolling when switching between commands with/without shortcuts
-    offsets->Update(style.ItemSpacing.x, true);
-
     // Check if any item in the full unfiltered list has an icon
     // If so, always reserve space for icons even when filtered results don't have any
     bool has_any_icon = false;

--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -680,7 +680,7 @@ void CommandPalette(const char* name, const char* hint)
     bool underline_highlight = gg.TextStyleFlags[ImCmdTextType_Highlight] & (1 << ImCmdTextFlag_Underline);
 
     // Could be 0.5 on macOS Retina, 1 elsewhere
-    float font_scale = ImGui::GetIO().FontGlobalScale;
+    float font_scale = ImGui::GetIO().FontScaleMain;
 
     if ((int)gi.ExtraData.size() < item_count) {
         gi.ExtraData.resize(item_count);

--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -939,6 +939,10 @@ void CommandPalette(const char* name, const char* hint)
     auto draw_list = window->DrawList;
     auto offsets = &window->DC.MenuColumns;
 
+    // Reset the MenuColumns to ensure we don't accumulate widths from previous frames or other command lists
+    // This prevents horizontal scrolling when switching between commands with/without shortcuts
+    offsets->Update(style.ItemSpacing.x, true);
+
     // Check if any item in the full unfiltered list has an icon
     // If so, always reserve space for icons even when filtered results don't have any
     bool has_any_icon = false;

--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -749,13 +749,20 @@ void CommandPalette(const char* name, const char* hint)
             int last_range_end = 0;
 
             auto DrawCurrentRange = [&]() {
+
+                #ifdef IMGUI_HAS_TEXTURES
+                auto fsz = font_regular->GetFontBaked(ImGui::GetFontSize())->Size;
+                #else
+                auto fsz = font_regular->FontSize;
+                #endif
+
                 if (range_begin != last_range_end) {
                     // Draw normal text between last highlighted range end and current highlighted range start
                     auto begin = text + last_range_end;
                     auto end = text + range_begin;
 
                     draw_list->AddText(text_pos, text_color_regular, begin, end);
-                    auto segment_size = font_regular->CalcTextSizeA(font_regular->FontSize * font_scale, std::numeric_limits<float>::max(), 0.0f, begin, end);
+                    auto segment_size = font_regular->CalcTextSizeA(fsz * font_scale, std::numeric_limits<float>::max(), 0.0f, begin, end);
 
                     if (underline_regular) {
                         float x1 = text_pos.x;
@@ -770,9 +777,15 @@ void CommandPalette(const char* name, const char* hint)
 
                 auto begin = text + range_begin;
                 auto end = text + range_end;
+                
+                #ifdef IMGUI_HAS_TEXTURES
+                fsz = font_highlight->GetFontBaked(ImGui::GetFontSize())->Size;
+                #else
+                fsz = font_highlight->FontSize;
+                #endif
 
-                draw_list->AddText(font_highlight, font_highlight->FontSize * font_scale, text_pos, text_color_highlight, begin, end);
-                auto segment_size = font_highlight->CalcTextSizeA(font_highlight->FontSize * font_scale, std::numeric_limits<float>::max(), 0.0f, begin, end);
+                draw_list->AddText(font_highlight, fsz * font_scale, text_pos, text_color_highlight, begin, end);
+                auto segment_size = font_highlight->CalcTextSizeA(fsz * font_scale, std::numeric_limits<float>::max(), 0.0f, begin, end);
 
                 if (underline_highlight) {
                     float x1 = text_pos.x;

--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -41,8 +41,21 @@ struct Instance;
 
 struct StackFrame
 {
+    ImCmdInputType InputType = ImCmdInputType_Discrete;
+
+    // For discrete options
     std::vector<std::string> Options;
     int SelectedOption = -1;
+
+    // For text/numeric input
+    char InputBuffer[256] = {};
+    std::string Hint;
+    HelpFunc GetHelpText;
+    ValidationFunc ValidateInput;
+
+    // For widget
+    std::function<bool()> WidgetCallback;
+    std::string WidgetHelpText;
 };
 
 class ExecutionManager
@@ -65,6 +78,11 @@ public:
     void SelectItem(int idx);
 
     void PushOptions(std::vector<std::string> options);
+    void PushPrompt(const PromptConfig& config);
+    void SubmitTextInput(const std::string& input);
+    void SubmitWidget();
+    ImCmdInputType GetCurrentInputType() const;
+    const StackFrame* GetCurrentFrame() const;
 };
 
 struct SearchResult
@@ -232,6 +250,7 @@ struct Instance
     {
         bool RefreshSearch = false;
         bool ClearSearch = false;
+        bool FocusInput = false;
     } PendingActions;
 
     Instance()
@@ -358,9 +377,121 @@ void ExecutionManager::PushOptions(std::vector<std::string> options)
     m_CallStack.push_back({});
     auto& frame = m_CallStack.back();
 
+    frame.InputType = ImCmdInputType_Discrete;
     frame.Options = std::move(options);
 
     m_Instance->PendingActions.ClearSearch = true;
+}
+
+void ExecutionManager::PushPrompt(const PromptConfig& config)
+{
+    m_CallStack.push_back({});
+    auto& frame = m_CallStack.back();
+
+    frame.InputType = config.Type;
+
+    switch (config.Type)
+    {
+        case ImCmdInputType_Discrete:
+            frame.Options = config.Options;
+            break;
+        case ImCmdInputType_Text:
+        case ImCmdInputType_Int:
+        case ImCmdInputType_Float:
+            frame.Hint = config.Hint;
+            frame.GetHelpText = config.GetHelpText;
+            frame.ValidateInput = config.ValidateInput;
+            m_Instance->PendingActions.FocusInput = true;
+            break;
+        case ImCmdInputType_Widget:
+            frame.WidgetCallback = config.WidgetCallback;
+            frame.WidgetHelpText = config.WidgetHelpText;
+            break;
+    }
+
+    m_Instance->PendingActions.ClearSearch = true;
+}
+
+void ExecutionManager::SubmitTextInput(const std::string& input)
+{
+    auto cmd = m_ExecutingCommand;
+    if (!cmd) return;
+
+    size_t initial_call_stack_height = m_CallStack.size();
+
+    gContext->IsExecuting = true;
+    InvokeSafe(cmd->TextInputCallback, input);
+    gContext->IsExecuting = false;
+
+    size_t final_call_stack_height = m_CallStack.size();
+    if (initial_call_stack_height == final_call_stack_height)
+    {
+        // Command completed
+        gContext->IsTerminating = true;
+        InvokeSafe(m_ExecutingCommand->TerminatingCallback);
+        gContext->IsTerminating = false;
+
+        m_ExecutingCommand = nullptr;
+        m_CallStack.clear();
+        --gContext->CommandStorageLocks;
+
+        m_Instance->PendingActions.ClearSearch = true;
+        m_Instance->CurrentSelectedItem = 0;
+
+        gContext->LastCommandPaletteStatus.ItemSelected = true;
+    } else
+    {
+        m_Instance->PendingActions.ClearSearch = true;
+        m_Instance->CurrentSelectedItem = 0;
+    }
+}
+
+void ExecutionManager::SubmitWidget()
+{
+    auto cmd = m_ExecutingCommand;
+    if (!cmd) return;
+
+    size_t initial_call_stack_height = m_CallStack.size();
+
+    gContext->IsExecuting = true;
+    InvokeSafe(cmd->WidgetCompleteCallback);
+    gContext->IsExecuting = false;
+
+    size_t final_call_stack_height = m_CallStack.size();
+    if (initial_call_stack_height == final_call_stack_height)
+    {
+        // Command completed
+        gContext->IsTerminating = true;
+        InvokeSafe(m_ExecutingCommand->TerminatingCallback);
+        gContext->IsTerminating = false;
+
+        m_ExecutingCommand = nullptr;
+        m_CallStack.clear();
+        --gContext->CommandStorageLocks;
+
+        m_Instance->PendingActions.ClearSearch = true;
+        m_Instance->CurrentSelectedItem = 0;
+
+        gContext->LastCommandPaletteStatus.ItemSelected = true;
+    } else
+    {
+        m_Instance->PendingActions.ClearSearch = true;
+        m_Instance->CurrentSelectedItem = 0;
+    }
+}
+
+ImCmdInputType ExecutionManager::GetCurrentInputType() const
+{
+    if (m_CallStack.empty())
+        return ImCmdInputType_Discrete;
+    return m_CallStack.back().InputType;
+}
+
+const StackFrame* ExecutionManager::GetCurrentFrame() const
+{
+    if (m_CallStack.empty())
+        return nullptr;
+    return &m_CallStack.back();
 }
 
 int SearchManager::GetItemCount() const
@@ -618,20 +749,125 @@ void CommandPalette(const char* name, const char* hint)
         gi.Search.RefreshSearchResults();
     }
 
+    // Save the FocusInput flag before clearing PendingActions
+    bool should_focus_input = gi.PendingActions.FocusInput;
+
     gi.PendingActions = {};
     // END procesisng PendingActions
 
-    if (gg.NextCommandPaletteActions.FocusSearchBox) {
-        // Focus the search box when user first brings command palette window up
-        // Note: this only affects the next frame
-        ImGui::SetKeyboardFocusHere(0);
+    // Determine the current input type
+    ImCmdInputType input_type = gi.Session.GetCurrentInputType();
+    const StackFrame* current_frame = gi.Session.GetCurrentFrame();
+
+    bool should_focus = gg.NextCommandPaletteActions.FocusSearchBox;
+    if (should_focus) {
         gg.NextCommandPaletteActions.FocusSearchBox = false;
     }
+
     float available_width = ImGui::GetContentRegionAvail().x;
     ImGui::SetNextItemWidth(available_width);
-    if (ImGui::InputTextWithHint("##SearchBox", hint, gi.Search.SearchText, IM_ARRAYSIZE(gi.Search.SearchText))) {
-        // Search string updated, update search results
-        gi.Search.RefreshSearchResults();
+
+    // Render appropriate input control based on input type
+    if (input_type == ImCmdInputType_Discrete)
+    {
+        // Original discrete search behavior
+        if (should_focus) {
+            ImGui::SetKeyboardFocusHere(0);
+        }
+        if (ImGui::InputTextWithHint("##SearchBox", hint, gi.Search.SearchText, IM_ARRAYSIZE(gi.Search.SearchText))) {
+            // Search string updated, update search results
+            gi.Search.RefreshSearchResults();
+        }
+    } else if (input_type == ImCmdInputType_Text || input_type == ImCmdInputType_Int || input_type == ImCmdInputType_Float)
+    {
+        // Text/numeric input field
+        char* input_buffer = current_frame ? const_cast<char*>(current_frame->InputBuffer) : nullptr;
+        const char* hint_text = current_frame ? current_frame->Hint.c_str() : "";
+
+        if (input_buffer)
+        {
+            ImGuiInputTextFlags input_flags = ImGuiInputTextFlags_EnterReturnsTrue;
+            if (input_type == ImCmdInputType_Int || input_type == ImCmdInputType_Float)
+                input_flags |= ImGuiInputTextFlags_CharsDecimal;
+
+            // Focus the input field if requested
+            if (should_focus_input) {
+                ImGui::SetKeyboardFocusHere(0);
+            }
+            bool submitted = ImGui::InputTextWithHint("##InputBox", hint_text, input_buffer, 256, input_flags);
+
+            // Validate input
+            std::string validation_error;
+            if (current_frame && current_frame->ValidateInput)
+            {
+                validation_error = current_frame->ValidateInput(input_buffer);
+            } else if (input_type == ImCmdInputType_Int && strlen(input_buffer) > 0)
+            {
+                // Default integer validation
+                char* end;
+                std::strtol(input_buffer, &end, 10);
+                if (*end != '\0')
+                    validation_error = "Must be an integer";
+            } else if (input_type == ImCmdInputType_Float && strlen(input_buffer) > 0)
+            {
+                // Default float validation
+                char* end;
+                std::strtof(input_buffer, &end);
+                if (*end != '\0')
+                    validation_error = "Must be a number";
+            }
+
+            // Show validation error or help text
+            if (!validation_error.empty())
+            {
+                ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "%s", validation_error.c_str());
+            } else if (current_frame && current_frame->GetHelpText)
+            {
+                std::string help_text = current_frame->GetHelpText(input_buffer);
+                if (!help_text.empty())
+                {
+                    ImGui::TextWrapped("%s", help_text.c_str());
+                }
+            }
+
+            // Submit on Enter key if validation passes
+            if (submitted && validation_error.empty() && strlen(input_buffer) > 0)
+            {
+                gi.Session.SubmitTextInput(input_buffer);
+            } else if (submitted)
+            {
+                // If Enter was pressed but validation failed, restore focus to the input
+                gi.PendingActions.FocusInput = true;
+            }
+        }
+
+        // Skip the list rendering for text/numeric input
+        ImGui::PopID();
+        return;
+    } else if (input_type == ImCmdInputType_Widget)
+    {
+        // Custom widget rendering
+        if (current_frame && current_frame->WidgetCallback)
+        {
+            // Show help text if available
+            if (!current_frame->WidgetHelpText.empty())
+            {
+                ImGui::TextWrapped("%s", current_frame->WidgetHelpText.c_str());
+                ImGui::Spacing();
+            }
+
+            // Call the widget callback
+            bool widget_complete = current_frame->WidgetCallback();
+
+            if (widget_complete)
+            {
+                gi.Session.SubmitWidget();
+            }
+        }
+
+        // Skip the list rendering for widget input
+        ImGui::PopID();
+        return;
     }
 
     int item_count = gi.Search.IsActive() ? gi.Search.GetItemCount() : gi.Session.GetItemCount();
@@ -676,6 +912,21 @@ void CommandPalette(const char* name, const char* hint)
     auto draw_list = window->DrawList;
     auto offsets = &window->DC.MenuColumns;
 
+    // Check if any item in the full unfiltered list has an icon
+    // If so, always reserve space for icons even when filtered results don't have any
+    bool has_any_icon = false;
+    float reserved_icon_width = 0.0f;
+    int full_item_count = gi.Session.GetItemCount();
+    for (int i = 0; i < full_item_count; ++i) {
+        auto icon = gi.Session.GetIcon(i);
+        if (icon && icon[0]) {
+            has_any_icon = true;
+            // Calculate the actual width of this icon to use as reserved space
+            reserved_icon_width = ImGui::CalcTextSize(icon, NULL).x;
+            break;
+        }
+    }
+
     // Flag used to delay item selection until after the loop ends
     bool select_focused_item = false;
     const ImGuiSelectableFlags selectable_flags = ImGuiSelectableFlags_SelectOnRelease | ImGuiSelectableFlags_NoSetKeyOwner | ImGuiSelectableFlags_SetNavIdOnHover | ImGuiSelectableFlags_SpanAvailWidth;
@@ -695,6 +946,10 @@ void CommandPalette(const char* name, const char* hint)
 
         ImVec2 text_size = ImGui::CalcTextSize(text, NULL, true);
         float icon_w = (icon && icon[0]) ? ImGui::CalcTextSize(icon, NULL).x : 0.0f;
+        // If any item in the full list has an icon, reserve space even if current item doesn't
+        if (has_any_icon && icon_w == 0.0f) {
+            icon_w = reserved_icon_width; // Use the actual width of an existing icon
+        }
         float shortcut_w = (shortcut && shortcut[0]) ? ImGui::CalcTextSize(shortcut, NULL).x : 0.0f;
         float checkmark_w = IM_TRUNC(g.FontSize * 1.20f);
         float min_w = offsets->DeclColumns(icon_w, text_size.x, shortcut_w, checkmark_w); // Feedback for next frame
@@ -877,6 +1132,66 @@ void FocusNextItem()
     gi.NextFrameScrollTo = 0.f;
 }
 
+void Submit()
+{
+    IM_ASSERT(gContext != nullptr);
+    IM_ASSERT(gContext->CurrentCommandPalette != nullptr);
+    auto& gi = *gContext->CurrentCommandPalette;
+
+    ImCmdInputType input_type = gi.Session.GetCurrentInputType();
+    const StackFrame* current_frame = gi.Session.GetCurrentFrame();
+
+    if (input_type == ImCmdInputType_Text || input_type == ImCmdInputType_Int || input_type == ImCmdInputType_Float)
+    {
+        // For text/numeric inputs, validate and submit
+        const char* input_buffer = current_frame ? current_frame->InputBuffer : "";
+
+        if (strlen(input_buffer) == 0)
+        {
+            gi.PendingActions.FocusInput = true;
+            return;
+        }
+
+        // Validate input
+        std::string validation_error;
+        if (current_frame && current_frame->ValidateInput)
+        {
+            validation_error = current_frame->ValidateInput(input_buffer);
+        } else if (input_type == ImCmdInputType_Int)
+        {
+            // Default integer validation
+            char* end;
+            std::strtol(input_buffer, &end, 10);
+            if (*end != '\0')
+                validation_error = "Must be an integer";
+        } else if (input_type == ImCmdInputType_Float)
+        {
+            // Default float validation
+            char* end;
+            std::strtof(input_buffer, &end);
+            if (*end != '\0')
+                validation_error = "Must be a number";
+        }
+
+        if (validation_error.empty())
+        {
+            gi.Session.SubmitTextInput(input_buffer);
+        } else
+        {
+            // If validation failed, restore focus to the input
+            gi.PendingActions.FocusInput = true;
+        }
+    } else if (input_type == ImCmdInputType_Widget)
+    {
+        // For widget inputs, trigger submission
+        gi.Session.SubmitWidget();
+    } else
+    {
+        // For discrete choices, select the focused item
+        SelectFocusedItem();
+    }
+}
+
 void EndCommandPalette()
 {
     IM_ASSERT(gContext != nullptr);
@@ -967,5 +1282,124 @@ void Prompt(std::vector<std::string> options)
 
     auto& gi = *gContext->CurrentCommandPalette;
     gi.Session.PushOptions(std::move(options));
+}
+
+void Prompt(const PromptConfig& config)
+{
+    IM_ASSERT(gContext != nullptr);
+    IM_ASSERT(gContext->CurrentCommandPalette != nullptr);
+    IM_ASSERT(gContext->IsExecuting);
+    IM_ASSERT(!gContext->IsTerminating);
+
+    auto& gi = *gContext->CurrentCommandPalette;
+    gi.Session.PushPrompt(config);
+}
+
+void PromptText(const std::string& hint, HelpFunc help_func, ValidationFunc validate_func)
+{
+    PromptConfig config;
+    config.Type = ImCmdInputType_Text;
+    config.Hint = hint;
+    config.GetHelpText = help_func;
+    config.ValidateInput = validate_func;
+    Prompt(config);
+}
+
+void PromptInt(const std::string& hint, HelpFunc help_func, ValidationFunc validate_func)
+{
+    PromptConfig config;
+    config.Type = ImCmdInputType_Int;
+    config.Hint = hint;
+    config.GetHelpText = help_func;
+    config.ValidateInput = validate_func;
+    Prompt(config);
+}
+
+void PromptFloat(const std::string& hint, HelpFunc help_func, ValidationFunc validate_func)
+{
+    PromptConfig config;
+    config.Type = ImCmdInputType_Float;
+    config.Hint = hint;
+    config.GetHelpText = help_func;
+    config.ValidateInput = validate_func;
+    Prompt(config);
+}
+
+void PromptWidget(std::function<bool()> widget_func, const std::string& help_text)
+{
+    PromptConfig config;
+    config.Type = ImCmdInputType_Widget;
+    config.WidgetCallback = widget_func;
+    config.WidgetHelpText = help_text;
+    Prompt(config);
+}
+
+ValidationFunc ValidateIntRange(int min_val, int max_val)
+{
+    return [min_val, max_val](const char* input) -> std::string {
+        if (strlen(input) == 0)
+            return ""; // Empty is OK, user still typing
+
+        char* end;
+        long val = std::strtol(input, &end, 10);
+
+        if (*end != '\0')
+            return "Must be an integer";
+
+        if (val < min_val || val > max_val)
+        {
+            char buf[256];
+            ImFormatString(buf, IM_ARRAYSIZE(buf), "Must be between %d and %d", min_val, max_val);
+            return buf;
+        }
+
+        return "";
+    };
+}
+
+ValidationFunc ValidateFloatRange(float min_val, float max_val)
+{
+    return [min_val, max_val](const char* input) -> std::string {
+        if (strlen(input) == 0)
+            return "";
+
+        char* end;
+        float val = std::strtof(input, &end);
+
+        if (*end != '\0')
+            return "Must be a number";
+
+        if (val < min_val || val > max_val)
+        {
+            char buf[256];
+            ImFormatString(buf, IM_ARRAYSIZE(buf), "Must be between %.2f and %.2f", min_val, max_val);
+            return buf;
+        }
+
+        return "";
+    };
+}
+
+ValidationFunc ValidateNotEmpty()
+{
+    return [](const char* input) -> std::string {
+        return (strlen(input) == 0) ? "Input required" : "";
+    };
+}
+
+ValidationFunc CombineValidators(std::vector<ValidationFunc> validators)
+{
+    return [validators = std::move(validators)](const char* input) -> std::string {
+        for (const auto& validator : validators)
+        {
+            if (validator)
+            {
+                std::string error = validator(input);
+                if (!error.empty())
+                    return error;
+            }
+        }
+        return "";
+    };
 }
 } // namespace ImCmd

--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -651,7 +651,7 @@ void CommandPalette(const char* name, const char* hint)
     // If the list of subcommands is wider, the window would grow as expected, but the command palette
     // would start at this larger width next time it is launched. Launching it yet again would
     // shrink it back to the autofit size.
-    ImGui::SetNextWindowSizeConstraints(ImVec2(available_width, 0), ImVec2(ImGui::GetMainViewport()->Size.x, remaining_height - 100.f));
+    ImGui::SetNextWindowSizeConstraints(ImVec2(available_width, ImGui::GetFrameHeight() * 3), ImVec2(ImGui::GetMainViewport()->Size.x, ImMax(ImGui::GetFrameHeight() * 3, remaining_height - 100.f)));
     ImGui::BeginChild("SearchResults", ImVec2(0, search_result_window_height), ImGuiChildFlags_FrameStyle | ImGuiChildFlags_AutoResizeX, ImGuiWindowFlags_NoSavedSettings);
 
     auto font_regular = gg.TextStyleFonts[ImCmdTextType_Regular];
@@ -690,6 +690,7 @@ void CommandPalette(const char* name, const char* hint)
     // Flag used to delay item selection until after the loop ends
     bool select_focused_item = false;
     const ImGuiSelectableFlags selectable_flags = ImGuiSelectableFlags_SelectOnRelease | ImGuiSelectableFlags_NoSetKeyOwner | ImGuiSelectableFlags_SetNavIdOnHover | ImGuiSelectableFlags_SpanAvailWidth;
+    static float sScrollToNextFrame = -1.f;
     for (int i = 0; i < item_count; ++i) {
         // Implement a custom button-like control
 
@@ -717,6 +718,13 @@ void CommandPalette(const char* name, const char* hint)
         {
             select_focused_item = true;
             gi.CurrentSelectedItem = i;
+        }
+
+        if (gi.CurrentSelectedItem == i && sScrollToNextFrame >= 0.f)
+        {
+            if (!ImGui::IsItemVisible())
+                ImGui::SetScrollHereY(sScrollToNextFrame);
+            sScrollToNextFrame = -1.f;
         }
 
         // Draw the icon, shortcut, and checkmark/arrow
@@ -852,8 +860,10 @@ void CommandPalette(const char* name, const char* hint)
 
     if (ImGui::Shortcut(ImGuiKey_UpArrow, ImGuiInputFlags_Repeat)) {
         gi.CurrentSelectedItem = ImMax(gi.CurrentSelectedItem - 1, 0);
+        sScrollToNextFrame = 1.f;
     } else if (ImGui::Shortcut(ImGuiKey_DownArrow, ImGuiInputFlags_Repeat)) {
         gi.CurrentSelectedItem = ImMin(gi.CurrentSelectedItem + 1, item_count - 1);
+        sScrollToNextFrame = 0.f;
     }
 
     ImGui::PopID();

--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -680,7 +680,7 @@ void CommandPalette(const char* name, const char* hint)
     bool underline_highlight = gg.TextStyleFlags[ImCmdTextType_Highlight] & (1 << ImCmdTextFlag_Underline);
 
     // Could be 0.5 on macOS Retina, 1 elsewhere
-    float font_scale = ImGui::GetIO().FontScaleMain;
+    float font_scale = ImGui::GetStyle().FontScaleMain;
 
     if ((int)gi.ExtraData.size() < item_count) {
         gi.ExtraData.resize(item_count);
@@ -750,11 +750,11 @@ void CommandPalette(const char* name, const char* hint)
 
             auto DrawCurrentRange = [&]() {
 
-                #ifdef IMGUI_HAS_TEXTURES
+#ifdef IMGUI_HAS_TEXTURES
                 auto fsz = font_regular->GetFontBaked(ImGui::GetFontSize())->Size;
-                #else
+#else
                 auto fsz = font_regular->FontSize;
-                #endif
+#endif
 
                 if (range_begin != last_range_end) {
                     // Draw normal text between last highlighted range end and current highlighted range start
@@ -777,12 +777,12 @@ void CommandPalette(const char* name, const char* hint)
 
                 auto begin = text + range_begin;
                 auto end = text + range_end;
-                
-                #ifdef IMGUI_HAS_TEXTURES
+
+#ifdef IMGUI_HAS_TEXTURES
                 fsz = font_highlight->GetFontBaked(ImGui::GetFontSize())->Size;
-                #else
+#else
                 fsz = font_highlight->FontSize;
-                #endif
+#endif
 
                 draw_list->AddText(font_highlight, fsz * font_scale, text_pos, text_color_highlight, begin, end);
                 auto segment_size = font_highlight->CalcTextSizeA(fsz * font_scale, std::numeric_limits<float>::max(), 0.0f, begin, end);

--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -679,9 +679,6 @@ void CommandPalette(const char* name, const char* hint)
     bool underline_regular = gg.TextStyleFlags[ImCmdTextType_Regular] & (1 << ImCmdTextFlag_Underline);
     bool underline_highlight = gg.TextStyleFlags[ImCmdTextType_Highlight] & (1 << ImCmdTextFlag_Underline);
 
-    // Could be 0.5 on macOS Retina, 1 elsewhere
-    float font_scale = ImGui::GetStyle().FontScaleMain;
-
     if ((int)gi.ExtraData.size() < item_count) {
         gi.ExtraData.resize(item_count);
     }
@@ -751,7 +748,7 @@ void CommandPalette(const char* name, const char* hint)
             auto DrawCurrentRange = [&]() {
 
 #ifdef IMGUI_HAS_TEXTURES
-                auto fsz = font_regular->GetFontBaked(ImGui::GetFontSize())->Size;
+                auto fsz = ImGui::GetFontSize();
 #else
                 auto fsz = font_regular->FontSize;
 #endif
@@ -762,7 +759,7 @@ void CommandPalette(const char* name, const char* hint)
                     auto end = text + range_begin;
 
                     draw_list->AddText(text_pos, text_color_regular, begin, end);
-                    auto segment_size = font_regular->CalcTextSizeA(fsz * font_scale, std::numeric_limits<float>::max(), 0.0f, begin, end);
+                    auto segment_size = font_regular->CalcTextSizeA(fsz, std::numeric_limits<float>::max(), 0.0f, begin, end);
 
                     if (underline_regular) {
                         float x1 = text_pos.x;
@@ -779,13 +776,13 @@ void CommandPalette(const char* name, const char* hint)
                 auto end = text + range_end;
 
 #ifdef IMGUI_HAS_TEXTURES
-                fsz = font_highlight->GetFontBaked(ImGui::GetFontSize())->Size;
+                fsz = ImGui::GetFontSize();
 #else
                 fsz = font_highlight->FontSize;
 #endif
 
-                draw_list->AddText(font_highlight, fsz * font_scale, text_pos, text_color_highlight, begin, end);
-                auto segment_size = font_highlight->CalcTextSizeA(fsz * font_scale, std::numeric_limits<float>::max(), 0.0f, begin, end);
+                draw_list->AddText(font_highlight, fsz, text_pos, text_color_highlight, begin, end);
+                auto segment_size = font_highlight->CalcTextSizeA(fsz, std::numeric_limits<float>::max(), 0.0f, begin, end);
 
                 if (underline_highlight) {
                     float x1 = text_pos.x;

--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -33,7 +33,6 @@ struct CommandOperationUnregister;
 struct CommandOperation;
 struct Context;
 
-struct ItemExtraData;
 struct Instance;
 
 // =================================================================
@@ -221,17 +220,11 @@ struct Context
     }
 };
 
-struct ItemExtraData
-{
-    bool Hovered = false;
-    bool Held = false;
-};
-
 struct Instance
 {
     ExecutionManager Session;
     SearchManager Search;
-    std::vector<ItemExtraData> ExtraData;
+    float NextFrameScrollTo = -1.f;
 
     int CurrentSelectedItem = 0;
 
@@ -679,10 +672,6 @@ void CommandPalette(const char* name, const char* hint)
     bool underline_regular = gg.TextStyleFlags[ImCmdTextType_Regular] & (1 << ImCmdTextFlag_Underline);
     bool underline_highlight = gg.TextStyleFlags[ImCmdTextType_Highlight] & (1 << ImCmdTextFlag_Underline);
 
-    if ((int)gi.ExtraData.size() < item_count) {
-        gi.ExtraData.resize(item_count);
-    }
-
     auto window = ImGui::GetCurrentContext()->CurrentWindow;
     auto draw_list = window->DrawList;
     auto offsets = &window->DC.MenuColumns;
@@ -690,7 +679,6 @@ void CommandPalette(const char* name, const char* hint)
     // Flag used to delay item selection until after the loop ends
     bool select_focused_item = false;
     const ImGuiSelectableFlags selectable_flags = ImGuiSelectableFlags_SelectOnRelease | ImGuiSelectableFlags_NoSetKeyOwner | ImGuiSelectableFlags_SetNavIdOnHover | ImGuiSelectableFlags_SpanAvailWidth;
-    static float sScrollToNextFrame = -1.f;
     for (int i = 0; i < item_count; ++i) {
         // Implement a custom button-like control
 
@@ -720,11 +708,11 @@ void CommandPalette(const char* name, const char* hint)
             gi.CurrentSelectedItem = i;
         }
 
-        if (gi.CurrentSelectedItem == i && sScrollToNextFrame >= 0.f)
+        if (gi.CurrentSelectedItem == i && gi.NextFrameScrollTo >= 0.f)
         {
             if (!ImGui::IsItemVisible())
-                ImGui::SetScrollHereY(sScrollToNextFrame);
-            sScrollToNextFrame = -1.f;
+                ImGui::SetScrollHereY(gi.NextFrameScrollTo);
+            gi.NextFrameScrollTo = -1.f;
         }
 
         // Draw the icon, shortcut, and checkmark/arrow
@@ -840,36 +828,59 @@ void CommandPalette(const char* name, const char* hint)
         ImGui::PopID();
     }
 
-    if (ImGui::IsKeyPressed(ImGuiKey_Enter) || select_focused_item) {
-        if (gi.Search.IsActive()) {
-            if (!gi.Search.SearchResults.empty())
-            {
-                auto idx = gi.Search.SearchResults[gi.CurrentSelectedItem].ItemIndex;
-                gi.Session.SelectItem(idx);
-            } else
-            {
-                // If the search is active and there are no results, we should focus the search box again
-                SetNextCommandPaletteSearchBoxFocused();
-            }
-        } else {
-            gi.Session.SelectItem(gi.CurrentSelectedItem);
-        }
-    }
-
     ImGui::EndChild();
 
-    if (ImGui::Shortcut(ImGuiKey_UpArrow, ImGuiInputFlags_Repeat)) {
-        gi.CurrentSelectedItem = ImMax(gi.CurrentSelectedItem - 1, 0);
-        sScrollToNextFrame = 1.f;
-    } else if (ImGui::Shortcut(ImGuiKey_DownArrow, ImGuiInputFlags_Repeat)) {
-        gi.CurrentSelectedItem = ImMin(gi.CurrentSelectedItem + 1, item_count - 1);
-        sScrollToNextFrame = 0.f;
+    if (select_focused_item) {
+        SelectFocusedItem();
     }
 
     ImGui::PopID();
+}
 
-    gg.CurrentCommandPalette = nullptr;
-    // END this command palette
+void SelectFocusedItem()
+{
+    IM_ASSERT(gContext != nullptr);
+    IM_ASSERT(gContext->CurrentCommandPalette != nullptr);
+    auto& gi = *gContext->CurrentCommandPalette;
+    if (gi.Search.IsActive()) {
+        if (!gi.Search.SearchResults.empty())
+        {
+            auto idx = gi.Search.SearchResults[gi.CurrentSelectedItem].ItemIndex;
+            gi.Session.SelectItem(idx);
+        } else
+        {
+            // If the search is active and there are no results, we should focus the search box again
+            SetNextCommandPaletteSearchBoxFocused();
+        }
+    } else {
+        gi.Session.SelectItem(gi.CurrentSelectedItem);
+    }
+}
+
+void FocusPreviousItem()
+{
+    IM_ASSERT(gContext != nullptr);
+    IM_ASSERT(gContext->CurrentCommandPalette != nullptr);
+    auto& gi = *gContext->CurrentCommandPalette;
+    int item_count = gi.Search.IsActive() ? gi.Search.GetItemCount() : gi.Session.GetItemCount();
+    gi.CurrentSelectedItem = ImMax(gi.CurrentSelectedItem - 1, 0);
+    gi.NextFrameScrollTo = 1.f;
+}
+
+void FocusNextItem()
+{
+    IM_ASSERT(gContext != nullptr);
+    IM_ASSERT(gContext->CurrentCommandPalette != nullptr);
+    auto& gi = *gContext->CurrentCommandPalette;
+    int item_count = gi.Search.IsActive() ? gi.Search.GetItemCount() : gi.Session.GetItemCount();
+    gi.CurrentSelectedItem = ImMin(gi.CurrentSelectedItem + 1, item_count - 1);
+    gi.NextFrameScrollTo = 0.f;
+}
+
+void EndCommandPalette()
+{
+    IM_ASSERT(gContext != nullptr);
+    gContext->CurrentCommandPalette = nullptr;
 }
 
 bool IsAnyItemSelected()
@@ -926,10 +937,20 @@ void CommandPaletteWindow(const char* name, bool* p_open)
 
     CommandPalette(name);
 
-    if (IsAnyItemSelected()) {
-        *p_open = false;
+    if (!IsAnyItemSelected())
+    {
+        if (ImGui::Shortcut(ImGuiKey_UpArrow, ImGuiInputFlags_Repeat)) {
+            FocusPreviousItem();
+        } else if (ImGui::Shortcut(ImGuiKey_DownArrow, ImGuiInputFlags_Repeat)) {
+            FocusNextItem();
+        } else if (ImGui::IsKeyPressed(ImGuiKey_Enter)) {
+            SelectFocusedItem();
+        }
     }
-    if (!ImGui::IsWindowFocused(ImGuiFocusedFlags_ChildWindows)) {
+
+    EndCommandPalette();
+
+    if (!ImGui::IsWindowFocused(ImGuiFocusedFlags_ChildWindows) || IsAnyItemSelected()) {
         // Close popup when user unfocused the command palette window (clicking elsewhere)
         *p_open = false;
     }

--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -161,7 +161,7 @@ struct Context
             Commands.end(),
             command,
             [](const Command& a, const Command& b) -> bool {
-                return ImStricmp(a.Name.c_str(), b.Name.c_str()) < 0;
+                return a.Priority > b.Priority || (a.Priority == b.Priority && ImStricmp(a.Name.c_str(), b.Name.c_str()) > 0);
             });
         Commands.insert(location, std::move(command));
     }

--- a/imcmd_command_palette.cpp
+++ b/imcmd_command_palette.cpp
@@ -91,6 +91,7 @@ struct SearchResult
     int Score;
     int MatchCount;
     uint8_t Matches[32];
+    int MatchedNameIndex = 0; // 0 if matched primary name, >0 for aliases (index into Names vector)
 };
 
 class SearchManager
@@ -178,7 +179,7 @@ struct Context
             Commands.end(),
             command,
             [](const Command& a, const Command& b) -> bool {
-                return a.Priority > b.Priority || (a.Priority == b.Priority && ImStricmp(a.Name.c_str(), b.Name.c_str()) > 0);
+                return a.Priority > b.Priority || (a.Priority == b.Priority && ImStricmp(a.Names[0].c_str(), b.Names[0].c_str()) > 0);
             });
         Commands.insert(location, std::move(command));
     }
@@ -189,12 +190,12 @@ struct Context
         {
             bool operator()(const Command& command, const char* str) const
             {
-                return ImStricmp(command.Name.c_str(), str) < 0;
+                return ImStricmp(command.Names[0].c_str(), str) < 0;
             }
 
             bool operator()(const char* str, const Command& command) const
             {
-                return ImStricmp(str, command.Name.c_str()) < 0;
+                return ImStricmp(str, command.Names[0].c_str()) < 0;
             }
         };
 
@@ -278,7 +279,7 @@ const char* ExecutionManager::GetItem(int idx) const
     if (m_ExecutingCommand) {
         return m_CallStack.back().Options[idx].c_str();
     } else {
-        return gContext->Commands[idx].Name.c_str();
+        return gContext->Commands[idx].Names[0].c_str();
     }
 }
 
@@ -556,10 +557,40 @@ void SearchManager::RefreshSearchResults()
     int item_count = m_Instance->Session.GetItemCount();
     for (int i = 0; i < item_count; ++i) {
         const char* text = m_Instance->Session.GetItem(i);
-        SearchResult result;
-        if (FuzzySearch(SearchText, text, result.Score, result.Matches, IM_ARRAYSIZE(result.Matches), result.MatchCount)) {
-            result.ItemIndex = i;
-            SearchResults.push_back(result);
+        SearchResult best_result;
+        best_result.ItemIndex = i;
+        best_result.Score = -1;
+        best_result.MatchedNameIndex = 0;
+
+        // Try matching against all names (primary name at index 0, aliases at 1+)
+        if (i < (int)gContext->Commands.size()) {
+            const auto& names = gContext->Commands[i].Names;
+            for (int name_idx = 0; name_idx < (int)names.size(); ++name_idx) {
+                SearchResult name_result;
+                if (FuzzySearch(SearchText, names[name_idx].c_str(), name_result.Score, name_result.Matches, IM_ARRAYSIZE(name_result.Matches), name_result.MatchCount)) {
+                    // Aliases get lower scores
+                    if (name_idx > 0)
+                        name_result.Score = name_result.Score * 0.75f;
+
+                    if (name_result.Score > best_result.Score) {
+                        best_result = name_result;
+                        best_result.ItemIndex = i;
+                        best_result.MatchedNameIndex = name_idx;
+                    }
+                }
+            }
+        } else {
+            // For subcommand options, just match against the text directly
+            SearchResult name_result;
+            if (FuzzySearch(SearchText, text, name_result.Score, name_result.Matches, IM_ARRAYSIZE(name_result.Matches), name_result.MatchCount)) {
+                best_result = name_result;
+                best_result.ItemIndex = i;
+                best_result.MatchedNameIndex = 0;
+            }
+        }
+
+        if (best_result.Score >= 0) {
+            SearchResults.push_back(best_result);
         }
     }
 
@@ -873,15 +904,11 @@ void CommandPalette(const char* name, const char* hint)
     int item_count = gi.Search.IsActive() ? gi.Search.GetItemCount() : gi.Session.GetItemCount();
 
     float remaining_height = ImGui::GetMainViewport()->Size.y - ImGui::GetCursorScreenPos().y;
-    float search_result_window_height = ImGui::GetTextLineHeightWithSpacing() * item_count + style.FramePadding.y - 1.0f;
+    float search_result_window_height = ImGui::GetTextLineHeightWithSpacing() * item_count + style.FramePadding.y;
 
-    // If the parent window is set to auto resize, then it and the child below will automatically
-    // grow based on the width of the search results. However, the behavior seems buggy:
-    // If the list of subcommands is wider, the window would grow as expected, but the command palette
-    // would start at this larger width next time it is launched. Launching it yet again would
-    // shrink it back to the autofit size.
-    ImGui::SetNextWindowSizeConstraints(ImVec2(available_width, ImGui::GetFrameHeight() * 3), ImVec2(ImGui::GetMainViewport()->Size.x, ImMax(ImGui::GetFrameHeight() * 3, remaining_height - 100.f)));
-    ImGui::BeginChild("SearchResults", ImVec2(0, search_result_window_height), ImGuiChildFlags_FrameStyle | ImGuiChildFlags_AutoResizeX, ImGuiWindowFlags_NoSavedSettings);
+    // Use the available width to prevent horizontal overflow
+    // The child window should fit within the parent window's content region
+    ImGui::BeginChild("SearchResults", ImVec2(available_width, ImMin(search_result_window_height, remaining_height - 100.f)), ImGuiChildFlags_FrameStyle, ImGuiWindowFlags_NoSavedSettings);
 
     auto font_regular = gg.TextStyleFonts[ImCmdTextType_Regular];
     if (!font_regular) {
@@ -991,89 +1018,127 @@ void CommandPalette(const char* name, const char* hint)
             // If we have started searching, draw text with highlights at matched chars
 
             auto& search_result = gi.Search.SearchResults[i];
+            bool is_alias_match = search_result.MatchedNameIndex > 0;
 
-            int range_begin;
-            int range_end;
-            int last_range_end = 0;
+            // Helper lambda to draw text with highlighted matches
+            auto DrawHighlightedText = [&](const char* display_text) {
+                int range_begin;
+                int range_end;
+                int last_range_end = 0;
 
-            auto DrawCurrentRange = [&]() {
+                auto DrawRange = [&]() {
+#ifdef IMGUI_HAS_TEXTURES
+                    auto fsz = ImGui::GetFontSize();
+#else
+                    auto fsz = font_regular->FontSize;
+#endif
 
+                    if (range_begin != last_range_end) {
+                        // Draw normal text between last highlighted range end and current highlighted range start
+                        auto begin = display_text + last_range_end;
+                        auto end = display_text + range_begin;
+
+                        draw_list->AddText(text_pos, text_color_regular, begin, end);
+                        auto segment_size = font_regular->CalcTextSizeA(fsz, std::numeric_limits<float>::max(), 0.0f, begin, end);
+
+                        if (underline_regular) {
+                            float x1 = text_pos.x;
+                            float x2 = text_pos.x + segment_size.x;
+                            float y = text_pos.y + segment_size.y;
+                            // TODO adjust this to be at text baseline instead
+                            draw_list->AddLine(ImVec2(x1, y), ImVec2(x2, y), text_color_regular);
+                        }
+
+                        text_pos.x += segment_size.x;
+                    }
+
+                    auto begin = display_text + range_begin;
+                    auto end = display_text + range_end;
+
+#ifdef IMGUI_HAS_TEXTURES
+                    fsz = ImGui::GetFontSize();
+#else
+                    fsz = font_highlight->FontSize;
+#endif
+
+                    draw_list->AddText(font_highlight, fsz, text_pos, text_color_highlight, begin, end);
+                    auto segment_size = font_highlight->CalcTextSizeA(fsz, std::numeric_limits<float>::max(), 0.0f, begin, end);
+
+                    if (underline_highlight) {
+                        float x1 = text_pos.x;
+                        float x2 = text_pos.x + segment_size.x;
+                        // TODO adjust this to be at text baseline instead
+                        float y = text_pos.y + segment_size.y;
+                        draw_list->AddLine(ImVec2(x1, y), ImVec2(x2, y), text_color_highlight);
+                    }
+
+                    text_pos.x += segment_size.x;
+                };
+
+                IM_ASSERT(search_result.MatchCount >= 1);
+                range_begin = search_result.Matches[0];
+                range_end = range_begin;
+
+                int last_char_idx = -1;
+                for (int j = 0; j < search_result.MatchCount; ++j) {
+                    int char_idx = search_result.Matches[j];
+
+                    if ( // These 2 indices are consecutive, extend our current range by 1
+                        char_idx == last_char_idx + 1) {
+                        ++range_end;
+                    } else {
+                        DrawRange();
+                        last_range_end = range_end;
+                        range_begin = char_idx;
+                        range_end = char_idx + 1;
+                    }
+
+                    last_char_idx = char_idx;
+                }
+                // Draw the remaining range (if any)
+
+                if (range_begin != range_end) {
+                    DrawRange();
+                }
+
+                // Draw the text after the last range (if any)
+                const char* remaining_text = display_text + range_end;
+                draw_list->AddText(text_pos, text_color_regular, remaining_text);
 #ifdef IMGUI_HAS_TEXTURES
                 auto fsz = ImGui::GetFontSize();
 #else
                 auto fsz = font_regular->FontSize;
 #endif
-
-                if (range_begin != last_range_end) {
-                    // Draw normal text between last highlighted range end and current highlighted range start
-                    auto begin = text + last_range_end;
-                    auto end = text + range_begin;
-
-                    draw_list->AddText(text_pos, text_color_regular, begin, end);
-                    auto segment_size = font_regular->CalcTextSizeA(fsz, std::numeric_limits<float>::max(), 0.0f, begin, end);
-
-                    if (underline_regular) {
-                        float x1 = text_pos.x;
-                        float x2 = text_pos.x + segment_size.x;
-                        float y = text_pos.y + segment_size.y;
-                        // TODO adjust this to be at text baseline instead
-                        draw_list->AddLine(ImVec2(x1, y), ImVec2(x2, y), text_color_regular);
-                    }
-
-                    text_pos.x += segment_size.x;
-                }
-
-                auto begin = text + range_begin;
-                auto end = text + range_end;
-
-#ifdef IMGUI_HAS_TEXTURES
-                fsz = ImGui::GetFontSize();
-#else
-                fsz = font_highlight->FontSize;
-#endif
-
-                draw_list->AddText(font_highlight, fsz, text_pos, text_color_highlight, begin, end);
-                auto segment_size = font_highlight->CalcTextSizeA(fsz, std::numeric_limits<float>::max(), 0.0f, begin, end);
-
-                if (underline_highlight) {
-                    float x1 = text_pos.x;
-                    float x2 = text_pos.x + segment_size.x;
-                    float y = text_pos.y + segment_size.y;
-                    // TODO adjust this to be at text baseline instead
-                    draw_list->AddLine(ImVec2(x1, y), ImVec2(x2, y), text_color_highlight);
-                }
-
-                text_pos.x += segment_size.x;
+                auto remaining_size = font_regular->CalcTextSizeA(fsz, std::numeric_limits<float>::max(), 0.0f, remaining_text);
+                text_pos.x += remaining_size.x;
             };
 
-            IM_ASSERT(search_result.MatchCount >= 1);
-            range_begin = search_result.Matches[0];
-            range_end = range_begin;
+            if (is_alias_match) {
+                // Matched an alias: show command name (unhighlighted) then alias (highlighted) in parentheses
+                draw_list->AddText(text_pos, text_color_regular, text);
+#ifdef IMGUI_HAS_TEXTURES
+                auto fsz = ImGui::GetFontSize();
+#else
+                auto fsz = font_regular->FontSize;
+#endif
+                auto name_size = font_regular->CalcTextSizeA(fsz, std::numeric_limits<float>::max(), 0.0f, text);
+                text_pos.x += name_size.x;
 
-            int last_char_idx = -1;
-            for (int j = 0; j < search_result.MatchCount; ++j) {
-                int char_idx = search_result.Matches[j];
+                const char* space_paren = " (";
+                draw_list->AddText(text_pos, text_color_regular, space_paren);
+                auto space_size = font_regular->CalcTextSizeA(fsz, std::numeric_limits<float>::max(), 0.0f, space_paren);
+                text_pos.x += space_size.x;
 
-                if (char_idx == last_char_idx + 1) {
-                    // These 2 indices are equal, extend our current range by 1
-                    ++range_end;
-                } else {
-                    DrawCurrentRange();
-                    last_range_end = range_end;
-                    range_begin = char_idx;
-                    range_end = char_idx + 1;
-                }
+                // Draw the highlighted alias
+                int actual_idx = search_result.ItemIndex;
+                const char* alias_text = gContext->Commands[actual_idx].Names[search_result.MatchedNameIndex].c_str();
+                DrawHighlightedText(alias_text);
 
-                last_char_idx = char_idx;
+                draw_list->AddText(text_pos, text_color_regular, ")");
+            } else {
+                // Normal case: matched the main name, highlight it
+                DrawHighlightedText(text);
             }
-
-            // Draw the remaining range (if any)
-            if (range_begin != range_end) {
-                DrawCurrentRange();
-            }
-
-            // Draw the text after the last range (if any)
-            draw_list->AddText(text_pos, text_color_regular, text + range_end); // Draw until \0
         } else {
             // Otherwise, just draw text as-is, there are no highlights
 

--- a/imcmd_command_palette.h
+++ b/imcmd_command_palette.h
@@ -34,6 +34,7 @@ struct Command
     std::function<void()> TerminatingCallback;
     std::string Icon = "";
     std::string Shortcut = "";
+    bool* IsChecked = nullptr;
 };
 
 // Initialization

--- a/imcmd_command_palette.h
+++ b/imcmd_command_palette.h
@@ -32,6 +32,8 @@ struct Command
     std::function<void()> InitialCallback;
     std::function<void(int selected_option)> SubsequentCallback;
     std::function<void()> TerminatingCallback;
+    std::string Icon = "";
+    std::string Shortcut = "";
 };
 
 // Initialization

--- a/imcmd_command_palette.h
+++ b/imcmd_command_palette.h
@@ -62,7 +62,7 @@ void ClearStyleColor(ImCmdTextType type); //< Clear the style color for the give
 // Command palette widget
 void SetNextCommandPaletteSearch(const char* text);
 void SetNextCommandPaletteSearchBoxFocused();
-void CommandPalette(const char* name);
+void CommandPalette(const char* name, const char* hint = nullptr);
 bool IsAnyItemSelected();
 
 void RemoveCache(const char* name);

--- a/imcmd_command_palette.h
+++ b/imcmd_command_palette.h
@@ -66,7 +66,14 @@ void ClearStyleColor(ImCmdTextType type); //< Clear the style color for the give
 // Command palette widget
 void SetNextCommandPaletteSearch(const char* text);
 void SetNextCommandPaletteSearchBoxFocused();
+// Must call EndCommandPalette() if CommandPalette() was called
 void CommandPalette(const char* name, const char* hint = nullptr);
+// The following 3 functions can only be called between CommandPalette() and EndCommandPalette()
+void SelectFocusedItem();
+void FocusPreviousItem();
+void FocusNextItem();
+// Must call EndCommandPalette() if CommandPalette() was called
+void EndCommandPalette();
 bool IsAnyItemSelected();
 
 void RemoveCache(const char* name);

--- a/imcmd_command_palette.h
+++ b/imcmd_command_palette.h
@@ -35,6 +35,7 @@ struct Command
     std::string Icon = "";
     std::string Shortcut = "";
     bool* IsChecked = nullptr;
+    int Priority = 0; //< Higher priority commands are listed first. Commands with the same Priority are sorted alphabetically by Name.
 };
 
 // Initialization

--- a/imcmd_command_palette.h
+++ b/imcmd_command_palette.h
@@ -41,7 +41,7 @@ using HelpFunc = std::function<std::string(const char*)>;
 
 struct Command
 {
-    std::string Name;
+    std::vector<std::string> Names; //< First element is the command name, subsequent elements are aliases
     std::function<void()> InitialCallback;
     std::function<void(int selected_option)> SubsequentCallback;
     std::function<void(const std::string& input_text)> TextInputCallback;
@@ -50,7 +50,7 @@ struct Command
     std::string Icon = "";
     std::string Shortcut = "";
     bool* IsChecked = nullptr;
-    int Priority = 0; //< Higher priority commands are listed first. Commands with the same Priority are sorted alphabetically by Name.
+    int Priority = 0; //< Higher priority commands are listed first. Commands with the same Priority are sorted alphabetically by Names[0].
 };
 
 struct PromptConfig

--- a/imcmd_command_palette.h
+++ b/imcmd_command_palette.h
@@ -17,6 +17,15 @@ enum ImCmdTextType
     ImCmdTextType_COUNT,
 };
 
+enum ImCmdInputType
+{
+    ImCmdInputType_Discrete, // List of discrete options (current behavior)
+    ImCmdInputType_Text, // Free-form text input
+    ImCmdInputType_Int, // Integer input (validated)
+    ImCmdInputType_Float, // Float input (validated)
+    ImCmdInputType_Widget, // Custom ImGui widget
+};
+
 enum ImCmdTextFlag
 {
     /// Whether the text is underlined. Default false.
@@ -26,16 +35,39 @@ enum ImCmdTextFlag
 
 namespace ImCmd
 {
+// Type aliases for callback functions
+using ValidationFunc = std::function<std::string(const char*)>;
+using HelpFunc = std::function<std::string(const char*)>;
+
 struct Command
 {
     std::string Name;
     std::function<void()> InitialCallback;
     std::function<void(int selected_option)> SubsequentCallback;
+    std::function<void(const std::string& input_text)> TextInputCallback;
+    std::function<void()> WidgetCompleteCallback;
     std::function<void()> TerminatingCallback;
     std::string Icon = "";
     std::string Shortcut = "";
     bool* IsChecked = nullptr;
     int Priority = 0; //< Higher priority commands are listed first. Commands with the same Priority are sorted alphabetically by Name.
+};
+
+struct PromptConfig
+{
+    ImCmdInputType Type = ImCmdInputType_Discrete;
+
+    // For ImCmdInputType_Discrete
+    std::vector<std::string> Options;
+
+    // For text/numeric input (Text, Int, Float)
+    std::string Hint;
+    HelpFunc GetHelpText;
+    ValidationFunc ValidateInput;
+
+    // For ImCmdInputType_Widget
+    std::function<bool()> WidgetCallback;
+    std::string WidgetHelpText;
 };
 
 // Initialization
@@ -68,10 +100,11 @@ void SetNextCommandPaletteSearch(const char* text);
 void SetNextCommandPaletteSearchBoxFocused();
 // Must call EndCommandPalette() if CommandPalette() was called
 void CommandPalette(const char* name, const char* hint = nullptr);
-// The following 3 functions can only be called between CommandPalette() and EndCommandPalette()
+// The following 4 functions can only be called between CommandPalette() and EndCommandPalette()
 void SelectFocusedItem();
 void FocusPreviousItem();
 void FocusNextItem();
+void Submit(); //< Submits the current input (text/widget) or selects the focused item (discrete choice)
 // Must call EndCommandPalette() if CommandPalette() was called
 void EndCommandPalette();
 bool IsAnyItemSelected();
@@ -83,7 +116,18 @@ void RemoveAllCaches();
 void SetNextWindowAffixedTop(ImGuiCond cond = 0);
 void CommandPaletteWindow(const char* name, bool* p_open);
 
+// Validation helper functions
+ValidationFunc ValidateIntRange(int min_val, int max_val);
+ValidationFunc ValidateFloatRange(float min_val, float max_val);
+ValidationFunc ValidateNotEmpty();
+ValidationFunc CombineValidators(std::vector<ValidationFunc> validators);
+
 // Command responses, only call these in command callbacks (except TerminatingCallback)
+void Prompt(const PromptConfig& config);
 void Prompt(std::vector<std::string> options);
+void PromptText(const std::string& hint = "", HelpFunc help_func = nullptr, ValidationFunc validate_func = nullptr);
+void PromptInt(const std::string& hint = "", HelpFunc help_func = nullptr, ValidationFunc validate_func = nullptr);
+void PromptFloat(const std::string& hint = "", HelpFunc help_func = nullptr, ValidationFunc validate_func = nullptr);
+void PromptWidget(std::function<bool()> widget_func, const std::string& help_text = "");
 
 } // namespace ImCmd


### PR DESCRIPTION
It seems the font scaling wasn't quite working properly on macOS, causing the command entries to be twice as tall as they need to be, and misalignment when highlighting:
<img width="364" alt="broken-alignment" src="https://github.com/user-attachments/assets/e82e2d16-d981-4f7a-9fab-720a062a15b2">

The two-line change now allows this to work properly:
<img width="365" alt="fixed-alignment" src="https://github.com/user-attachments/assets/53792ffd-21cb-485a-9e5a-b441414ff7cf">

